### PR TITLE
Switch to OpenRouter API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # API Keys for different services
 GEMINI_API_KEY="your_gemini_api_key_here"
-DEEPSEEK_API_KEY="your_deepseek_api_key_here"
+OPENROUTER_API_KEY="your_openrouter_api_key_here"

--- a/client/index.html
+++ b/client/index.html
@@ -23,7 +23,7 @@
       <label>Model
         <select id="model">
           <option value="Gemini">Gemini</option>
-          <option value="DeepSeek">DeepSeek</option>
+          <option value="OpenRouter">OpenRouter</option>
         </select>
       </label>
       <label>Temperature <input type="range" id="temp" min="0" max="1" step="0.1" value="0.7"></label>

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ let conversations = {};
 // Helper to fetch API key based on model
 function getApiKey(model) {
   if (model === 'Gemini') return process.env.GEMINI_API_KEY || '';
-  if (model === 'DeepSeek') return process.env.DEEPSEEK_API_KEY || '';
+  if (model === 'OpenRouter') return process.env.OPENROUTER_API_KEY || '';
   return '';
 }
 


### PR DESCRIPTION
## Summary
- support `OPENROUTER_API_KEY` instead of DeepSeek API key
- update model select dropdown to OpenRouter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f511a9160832caaa41bf6b765722c